### PR TITLE
dev/1.1.1

### DIFF
--- a/@types/client.d.ts
+++ b/@types/client.d.ts
@@ -53,7 +53,7 @@ export class ClientFunctions {
       *  @param textype: type of notification to display
       *  @param length: amount of time to display for 
       */
-     Notify(text: string, textype: "success" | "primary" | "error", length: number): void
+     Notify(text: string | Notification, textype: string, length: number): void
    
      /** QBCore.Functions.TriggerCallback: Triggers a callback function 
       *  @param name: Name of the registered callback
@@ -204,4 +204,9 @@ export declare interface VehicleProperties {
   modTank: number;
   modWindows: number;
   modLivery: number;
+}
+
+declare interface Notification {
+  text: string;
+  caption: string;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbcore.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Type definitions for QBCore Framework, based on esx.js by itschip",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Update to version 1.1.1
- New Notification syntax
- `type` argument for QBCore.Functions.Notify now takes a generic string instead of specific strings